### PR TITLE
Add filter for webhook request arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,9 @@ You can run code directly before or after you fire the webhook using the followi
 * Before: `jamstack_deployments_before_fire_webhook`
 * After: `jamstack_deployments_after_fire_webhook`
 
+## Changing Webhook Request Arguments
+
+You can modify the arguments sent to the `wp_remote_safe_*` functions using the `jamstack_deployments_webhook_request_args` filter.
+
 ## License
 [GPL-3.0](LICENSE.md)

--- a/src/WebhookTrigger.php
+++ b/src/WebhookTrigger.php
@@ -245,9 +245,9 @@ class WebhookTrigger
             return;
         }
 
-        $args = [
+        $args = apply_filters('jamstack_deployments_webhook_request_args', [
             'blocking' => false
-        ];
+        ]);
 
         $method = jamstack_deployments_get_webhook_method();
 

--- a/wp-jamstack-deployments.php
+++ b/wp-jamstack-deployments.php
@@ -5,7 +5,7 @@
  * Description: A WordPress plugin for JAMstack deployments on Netlify (and other platforms).
  * Author: Christopher Geary
  * Author URI: https://crgeary.com
- * Version: 0.2.1
+ * Version: 0.2.2
  */
 
 if (!defined('ABSPATH')) {


### PR DESCRIPTION
Fixes #11

Allow developers to hook in and change the array passed to `wp_remote_safe_get` and `wp_remote_safe_post` functions for the webhook. 