### PR TITLE
Fix PHP notice for unset key in array

### DIFF
--- a/src/Field.php
+++ b/src/Field.php
@@ -47,7 +47,7 @@ class Field
         $args['value'] = is_array($args['value']) ? $args['value'] : [$args['value']];
 
         ?><fieldset>
-            <legend class="screen-reader-text"><?= $args['label']; ?></legend>
+            <legend class="screen-reader-text"><?= $args['legend']; ?></legend>
             <?php foreach ($args['choices'] as $k => $v) : ?>
                 <label>
                     <input type="checkbox"


### PR DESCRIPTION
Looking at [Settings](https://github.com/crgeary/wp-jamstack-deployments/blob/master/src/Settings.php#L61), I think this is supposed to be `legend` not `label`