### PR TITLE
Fix "Test Webhook" button on Settings Page

### DIFF
--- a/src/UI/SettingsScreen.php
+++ b/src/UI/SettingsScreen.php
@@ -57,8 +57,8 @@ class SettingsScreen
 
                 ?>
 
-                <p>You must save your settings before testing.</p>
-                <a href="<?= esc_url($uri); ?>" class="button">Test Webhook</a>
+                <p>You must save your settings before testing a deployment.</p>
+                <a href="<?= esc_url($uri); ?>" class="button">Test Deployment</a>
 
             </form>
 

--- a/src/WebhookTrigger.php
+++ b/src/WebhookTrigger.php
@@ -11,6 +11,7 @@ class WebhookTrigger
      */
     public static function init()
     {
+        add_action('admin_init', [__CLASS__, 'trigger']);
         add_action('admin_bar_menu', [__CLASS__, 'adminBarTriggerButton']);
 
         add_action('admin_footer', [__CLASS__, 'adminBarCssAndJs']);
@@ -19,7 +20,7 @@ class WebhookTrigger
         add_action('wp_enqueue_scripts', [__CLASS__, 'enqueueScripts']);
         add_action('admin_enqueue_scripts', [__CLASS__, 'enqueueScripts']);
 
-        add_action('wp_ajax_wp_jamstack_deployments_manual_trigger', [__CLASS__, 'trigger']);
+        add_action('wp_ajax_wp_jamstack_deployments_manual_trigger', [__CLASS__, 'ajaxTrigger']);
     }
 
     /**
@@ -219,6 +220,25 @@ class WebhookTrigger
      * @return void
      */
     public static function trigger()
+    {
+        if (!isset($_GET['action']) || 'jamstack-deployment-trigger' !== $_GET['action']) {
+            return;
+        }
+        
+        check_admin_referer('crgeary_jamstack_deployment_trigger', 'crgeary_jamstack_deployment_trigger');
+
+        self::fireWebhook();
+
+        wp_redirect(admin_url('admin.php?page=wp-jamstack-deployments-settings'));
+        exit;
+    }
+
+    /**
+     * Trigger a request manually from the admin settings
+     *
+     * @return void
+     */
+    public static function ajaxTrigger()
     {
         check_ajax_referer('wp-jamstack-deployments-button-nonce', 'security');
 


### PR DESCRIPTION
The function to trigger a webhook via the test button was missing after I migrated code to use Ajax instead. I've put it back in.