### PR TITLE
Allow deploy image/buttons to have custom links

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ From this screen you can configure the following:
 
 - **Webhook URL** - The webhook URL that you have created to trigger a deployment. For more information on webhooks with Netlify [visit the Netlify documentation](https://www.netlify.com/docs/webhooks/).
 - **Webhook Method** - This is the required method for the webhook request. The available options are `GET` or `POST`. By default the plugin will automatically select `POST`.
+- **Badge Image URL** - An optional field to specify the `src` of a badge, for services that support badges.
+- **Badge Link** - An optional field to specify the `href` of a badge, for services that support badges.
 - **Post Types** - A list of selectable post types that will trigger a Netlify deployment when created, updated or deleted. Note that only selected post types will trigger a deployment.
 - **Taxonomies** - A list of selectable taxonomies that will trigger a Netlify deployment when created, updated or deleted. Note that only selected taxonomies will trigger a deployment.
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -47,10 +47,16 @@ class Settings
             'description' => 'Set either GET or POST for the webhook request. Defaults to POST.'
         ]);
 
-        add_settings_field('netlify_badge_url', 'Netlify Badge URL', ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [
+        add_settings_field('netlify_badge_url', 'Badge Image URL', ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [
             'name' => "{$key}[netlify_badge_url]",
             'value' => isset($option['netlify_badge_url']) ? $option['netlify_badge_url'] : '',
             'description' => 'Your Badge URL. See <a href="https://www.netlify.com/docs/continuous-deployment/" target="_blank" rel="noopener noreferrer">Netlify docs</a>.'
+        ]);
+
+        add_settings_field('deployment_badge_link_url', 'Badge Link', ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [
+            'name' => "{$key}[deployment_badge_link_url]",
+            'value' => isset($option['deployment_badge_link_url']) ? $option['deployment_badge_link_url'] : '',
+            'description' => 'The link to your deployments. See <a href="https://www.netlify.com/docs/continuous-deployment/" target="_blank" rel="noopener noreferrer">Netlify docs</a>.'
         ]);
 
         add_settings_field('webhook_post_types', 'Post Types', ['Crgeary\JAMstackDeployments\Field', 'checkboxes'], $key, 'general', [

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -47,9 +47,9 @@ class Settings
             'description' => 'Set either GET or POST for the webhook request. Defaults to POST.'
         ]);
 
-        add_settings_field('netlify_badge_url', 'Badge Image URL', ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [
-            'name' => "{$key}[netlify_badge_url]",
-            'value' => isset($option['netlify_badge_url']) ? $option['netlify_badge_url'] : '',
+        add_settings_field('deployment_badge_url', 'Badge Image URL', ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [
+            'name' => "{$key}[deployment_badge_url]",
+            'value' => self::getBadgeImageUrl($option),
             'description' => 'Your Badge URL. See <a href="https://www.netlify.com/docs/continuous-deployment/" target="_blank" rel="noopener noreferrer">Netlify docs</a>.'
         ]);
 
@@ -74,6 +74,21 @@ class Settings
             'description' => 'Only selected taxonomies will trigger a deployment when their terms are created, updated or deleted.',
             'legend' => 'Taxonomies'
         ]);
+    }
+
+    /**
+     * Get the badge image URL, has fallback to old option name
+     *
+     * @param array $option
+     * @return string
+     */
+    protected static function getBadgeImageUrl($option)
+    {
+        if (!empty($option['deployment_badge_url'])) {
+            return $option['deployment_badge_url'];
+        }
+
+        return !empty($option['netlify_badge_url']) ? $option['netlify_badge_url'] : '';
     }
 
     /**

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -33,7 +33,7 @@ class Settings
         add_settings_field('webhook_url', 'Webhook URL', ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [
             'name' => "{$key}[webhook_url]",
             'value' => jamstack_deployments_get_webhook_url(),
-            'description' => 'Your Webhook URL. See <a href="https://www.netlify.com/docs/webhooks/" target="_blank" rel="noopener noreferrer">Netlify docs</a>.'
+            'description' => 'Your Webhook URL. See <a href="https://www.netlify.com/docs/webhooks/" target="_blank" rel="noopener noreferrer">Netlify docs</a> or see <a href="https://zeit.co/docs/v2/advanced/deploy-hooks/" target="_blank" rel="noopener noreferrer">Zeit docs</a>.'
         ]);
 
         add_settings_field('webhook_method', 'Webhook Method', ['Crgeary\JAMstackDeployments\Field', 'select'], $key, 'general', [

--- a/src/WebhookTrigger.php
+++ b/src/WebhookTrigger.php
@@ -190,11 +190,18 @@ class WebhookTrigger
     public static function adminBarTriggerButton($bar)
     {
         $option = jamstack_deployments_get_options();
+        $image = '';
 
-        if (!empty($option['netlify_badge_url'])) {
+        if (!empty($option['deployment_badge_url'])) {
+            $image = $option['deployment_badge_url'];
+        } else if (!empty($option['netlify_badge_url'])) {
+            $image = $option['netlify_badge_url'];
+        }
+
+        if (!empty($image)) {
             $bar->add_node([
                 'id' => 'wp-jamstack-deployments-netlify-badge',
-                'title' => sprintf('<img src="%s" alt />', $option['netlify_badge_url']),
+                'title' => sprintf('<img src="%s" alt />', $image),
                 'href' => empty($option['deployment_badge_link_url']) ? 'javascript:void(0)' : $option['deployment_badge_link_url'],
                 'parent' => 'top-secondary',
                 'meta' => [

--- a/src/WebhookTrigger.php
+++ b/src/WebhookTrigger.php
@@ -195,10 +195,11 @@ class WebhookTrigger
             $bar->add_node([
                 'id' => 'wp-jamstack-deployments-netlify-badge',
                 'title' => sprintf('<img src="%s" alt />', $option['netlify_badge_url']),
-                'href' => 'javascript:void(0)',
+                'href' => empty($option['deployment_badge_link_url']) ? 'javascript:void(0)' : $option['deployment_badge_link_url'],
                 'parent' => 'top-secondary',
                 'meta' => [
-                    'class' => 'wp-jamstack-deployments-badge'
+                    'class' => 'wp-jamstack-deployments-badge',
+                    'target' => empty($option['deployment_badge_link_url']) ? '_self' : '_blank',
                 ]
             ]);
         }

--- a/wp-jamstack-deployments.php
+++ b/wp-jamstack-deployments.php
@@ -5,7 +5,7 @@
  * Description: A WordPress plugin for JAMstack deployments on Netlify (and other platforms).
  * Author: Christopher Geary
  * Author URI: https://crgeary.com
- * Version: 0.2.3
+ * Version: 0.3.0
  */
 
 if (!defined('ABSPATH')) {


### PR DESCRIPTION
Provide a way to set a custom URL for the deployment status image hyperlinks. Also made the the options more generic so not to specifically target netlify.