### PR TITLE
Changes some wording and adds i18n to settings page

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -33,7 +33,7 @@ class Settings
         add_settings_field('webhook_url', __( 'Build Hook URL', 'wp-jamstack-deployments' ), ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [
             'name' => "{$key}[webhook_url]",
             'value' => jamstack_deployments_get_webhook_url(),
-            'description' => sprintf( __( 'Your Build Hook URL. This is the URL that is pinged to start buidling/deploying the JAMstack site. See <a href="%1s" target="_blank" rel="noopener noreferrer">Netlify docs</a> or see <a href="%2s" target="_blank" rel="noopener noreferrer">Zeit docs</a>.', 'wp-jamstack-deployments' ), 'https://docs.netlify.com/configure-builds/build-hooks/', 'https://zeit.co/docs/v2/advanced/deploy-hooks/' )
+            'description' => sprintf( __( 'Your Build Hook URL. This is the URL that is pinged to start building/deploying the JAMstack site. See <a href="%1s" target="_blank" rel="noopener noreferrer">Netlify docs</a> or see <a href="%2s" target="_blank" rel="noopener noreferrer">Zeit docs</a>.', 'wp-jamstack-deployments' ), 'https://docs.netlify.com/configure-builds/build-hooks/', 'https://zeit.co/docs/v2/advanced/deploy-hooks/' )
         ]); 
 
         add_settings_field('webhook_method', __( 'Hook Method', 'wp-jamstack-deployments' ), ['Crgeary\JAMstackDeployments\Field', 'select'], $key, 'general', [
@@ -50,7 +50,7 @@ class Settings
         add_settings_field('deployment_badge_url', __( 'Badge Image URL', 'wp-jamstack-deployments' ), ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [
             'name' => "{$key}[deployment_badge_url]",
             'value' => self::getBadgeImageUrl($option),
-            'description' => sprintf( __( 'Your Badge URL. Input the URL to display a badge with the current site status on your WordPress Back end. See <a href="%1s" target="_blank" rel="noopener noreferrer">Netlify docs</a>.', 'wp-jamstack-deployments' ), 'https://docs.netlify.com/monitor-sites/status-badges/#add-status-badges' )
+            'description' => sprintf( __( 'Your Badge URL. Input the URL to display a badge with the current site status on your WordPress back end. See <a href="%1s" target="_blank" rel="noopener noreferrer">Netlify docs</a>.', 'wp-jamstack-deployments' ), 'https://docs.netlify.com/monitor-sites/status-badges/#add-status-badges' )
         ]);
 
         add_settings_field('deployment_badge_link_url', __( 'Badge Link', 'wp-jamstack-deployments' ), ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -24,19 +24,19 @@ class Settings
         $key = CRGEARY_JAMSTACK_DEPLOYMENTS_OPTIONS_KEY;
 
         register_setting($key, $key, [__CLASS__, 'sanitize']);
-        add_settings_section('general', 'General', '__return_empty_string', $key);
+        add_settings_section('general', __( 'General', 'wp-jamstack-deployments'), '__return_empty_string', $key);
         
         // ...
 
         $option = jamstack_deployments_get_options();
 
-        add_settings_field('webhook_url', 'Webhook URL', ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [
+        add_settings_field('webhook_url', __( 'Build Hook URL', 'wp-jamstack-deployments' ), ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [
             'name' => "{$key}[webhook_url]",
             'value' => jamstack_deployments_get_webhook_url(),
-            'description' => 'Your Webhook URL. See <a href="https://www.netlify.com/docs/webhooks/" target="_blank" rel="noopener noreferrer">Netlify docs</a> or see <a href="https://zeit.co/docs/v2/advanced/deploy-hooks/" target="_blank" rel="noopener noreferrer">Zeit docs</a>.'
-        ]);
+            'description' => sprintf( __( 'Your Build Hook URL. This is the URL that is pinged to start buidling/deploying the JAMstack site. See <a href="%1s" target="_blank" rel="noopener noreferrer">Netlify docs</a> or see <a href="%2s" target="_blank" rel="noopener noreferrer">Zeit docs</a>.', 'wp-jamstack-deployments' ), 'https://docs.netlify.com/configure-builds/build-hooks/', 'https://zeit.co/docs/v2/advanced/deploy-hooks/' )
+        ]); 
 
-        add_settings_field('webhook_method', 'Webhook Method', ['Crgeary\JAMstackDeployments\Field', 'select'], $key, 'general', [
+        add_settings_field('webhook_method', __( 'Hook Method', 'wp-jamstack-deployments' ), ['Crgeary\JAMstackDeployments\Field', 'select'], $key, 'general', [
             'name' => "{$key}[webhook_method]",
             'value' => jamstack_deployments_get_webhook_method(),
             'choices' => [
@@ -44,34 +44,34 @@ class Settings
                 'get' => 'GET'
             ],
             'default' => 'post',
-            'description' => 'Set either GET or POST for the webhook request. Defaults to POST.'
+            'description' => __( 'Set either GET or POST for the build hook request. Defaults to POST.', 'wp-jamstack-deployments' )
         ]);
 
-        add_settings_field('deployment_badge_url', 'Badge Image URL', ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [
+        add_settings_field('deployment_badge_url', __( 'Badge Image URL', 'wp-jamstack-deployments' ), ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [
             'name' => "{$key}[deployment_badge_url]",
             'value' => self::getBadgeImageUrl($option),
-            'description' => 'Your Badge URL. See <a href="https://www.netlify.com/docs/continuous-deployment/" target="_blank" rel="noopener noreferrer">Netlify docs</a>.'
+            'description' => sprintf( __( 'Your Badge URL. Input the URL to display a badge with the current site status on your WordPress Back end. See <a href="%1s" target="_blank" rel="noopener noreferrer">Netlify docs</a>.', 'wp-jamstack-deployments' ), 'https://docs.netlify.com/monitor-sites/status-badges/#add-status-badges' )
         ]);
 
-        add_settings_field('deployment_badge_link_url', 'Badge Link', ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [
+        add_settings_field('deployment_badge_link_url', __( 'Badge Link', 'wp-jamstack-deployments' ), ['Crgeary\JAMstackDeployments\Field', 'url'], $key, 'general', [
             'name' => "{$key}[deployment_badge_link_url]",
             'value' => isset($option['deployment_badge_link_url']) ? $option['deployment_badge_link_url'] : '',
-            'description' => 'The link to your deployments. See <a href="https://www.netlify.com/docs/continuous-deployment/" target="_blank" rel="noopener noreferrer">Netlify docs</a>.'
+            'description' => sprintf( __( 'The link to your deployments. See <a href="%1s" target="_blank" rel="noopener noreferrer">Netlify docs</a>.', 'wp-jamstack-deployments' ), 'https://www.netlify.com/docs/continuous-deployment/' )
         ]);
 
-        add_settings_field('webhook_post_types', 'Post Types', ['Crgeary\JAMstackDeployments\Field', 'checkboxes'], $key, 'general', [
+        add_settings_field('webhook_post_types', __( 'Post Types', 'wp-jamstack-deployments' ), ['Crgeary\JAMstackDeployments\Field', 'checkboxes'], $key, 'general', [
             'name' => "{$key}[webhook_post_types]",
             'value' => isset($option['webhook_post_types']) ? $option['webhook_post_types'] : [],
             'choices' => self::getPostTypes(),
-            'description' => 'Only selected post types will trigger a deployment when created, updated or deleted.',
+            'description' => __( 'Only selected post types will trigger a deployment when created, updated or deleted.', 'wp-jamstack-deployments' ),
             'legend' => 'Post Types'
         ]);
 
-        add_settings_field('webhook_taxonomies', 'Taxonomies', ['Crgeary\JAMstackDeployments\Field', 'checkboxes'], $key, 'general', [
+        add_settings_field('webhook_taxonomies', __( 'Taxonomies', 'wp-jamstack-deployments' ), ['Crgeary\JAMstackDeployments\Field', 'checkboxes'], $key, 'general', [
             'name' => "{$key}[webhook_taxonomies]",
             'value' => isset($option['webhook_taxonomies']) ? $option['webhook_taxonomies'] : [],
             'choices' => self::getTaxonomies(),
-            'description' => 'Only selected taxonomies will trigger a deployment when their terms are created, updated or deleted.',
+            'description' => __( 'Only selected taxonomies will trigger a deployment when their terms are created, updated or deleted.', 'wp-jamstack-deployments' ),
             'legend' => 'Taxonomies'
         ]);
     }

--- a/src/UI/SettingsScreen.php
+++ b/src/UI/SettingsScreen.php
@@ -22,8 +22,8 @@ class SettingsScreen
     public static function addMenu()
     {
         add_options_page(
-            'JAMstack Deployments (Settings)',
-            'Deployments',
+            __( 'JAMstack Deployments (Settings)', 'wp-jamstack-deployments' ),
+            __( 'Deployments', 'wp-jamstack-deployments' ),
             'manage_options',
             'wp-jamstack-deployments-settings',
             [__CLASS__, 'renderPage']
@@ -47,7 +47,7 @@ class SettingsScreen
                 settings_fields(CRGEARY_JAMSTACK_DEPLOYMENTS_OPTIONS_KEY);
                 do_settings_sections(CRGEARY_JAMSTACK_DEPLOYMENTS_OPTIONS_KEY);
 
-                submit_button('Save Settings', 'primary', 'submit', false);
+                submit_button( __( 'Save Settings', 'wp-jamstack-deployments' ), 'primary', 'submit', false);
 
                 $uri = wp_nonce_url(
                     admin_url('admin.php?page=wp-jamstack-deployments-settings&action=jamstack-deployment-trigger'),
@@ -57,8 +57,8 @@ class SettingsScreen
 
                 ?>
 
-                <p>You must save your settings before testing a deployment.</p>
-                <a href="<?= esc_url($uri); ?>" class="button">Test Deployment</a>
+                <p><?php _e( 'You must save your settings before testing a deployment.', 'wp-jamstack-deployments')?> </p>
+                <a href="<?= esc_url($uri); ?>" class="button"> <?php _e('Test Deployment', 'wpjamstack-deployments' ) ?> </a>
 
             </form>
 


### PR DESCRIPTION
This PR changes some wording on the setting page to make it clearer.
Resolves #25 

It also adds internationalization to the strings output on that setting page.

NOTE: I do not fully understand sanitization and how those i18n functions `__()` and `sprintf()`might be exploited to pose a security risk, but I have tested to confirm that all functionality works as expected on a test install. 