### PR TITLE
Fix duplicate triggers for builds 

### DIFF
--- a/src/WebhookTrigger.php
+++ b/src/WebhookTrigger.php
@@ -21,8 +21,6 @@ class WebhookTrigger
         add_action('admin_enqueue_scripts', [__CLASS__, 'enqueueScripts']);
 
         add_action('wp_ajax_wp_jamstack_deployments_manual_trigger', [__CLASS__, 'ajaxTrigger']);
-
-        add_action('transition_post_status', [__CLASS__, 'triggerPostTransition'], 10, 3);
     }
 
     /**
@@ -258,7 +256,8 @@ class WebhookTrigger
         $id = $post->ID;
         $option = jamstack_deployments_get_options();
         
-        $post_types = apply_filters('jamstack_deployments_post_types', $option['webhook_post_types'] ?: [], $id, $post);
+        $saved_post_types = isset($option['webhook_post_types']) ? $option['webhook_post_types'] : [];
+        $post_types = apply_filters('jamstack_deployments_post_types', $saved_post_types, $id, $post);
 
         if (!in_array(get_post_type($id), $post_types, true)) {
             return;
@@ -267,10 +266,6 @@ class WebhookTrigger
         $statuses = apply_filters('jamstack_deployments_post_statuses', ['publish', 'private', 'trash'], $id, $post);
 
         if (!in_array(get_post_status($id), $statuses, true)) {
-            return;
-        }
-
-        if ($new !== $old) {
             return;
         }
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -70,7 +70,23 @@ if (!function_exists('jamstack_deployments_fire_webhook_save_post')) {
     function jamstack_deployments_fire_webhook_save_post($id, $post, $update) {
         \Crgeary\JAMstackDeployments\WebhookTrigger::triggerSavePost($id, $post, $update);
     }
-    add_action('save_post', 'jamstack_deployments_fire_webhook_save_post', 10, 3);
+    // duplicates functionality of 'transition_post_status'
+    // add_action('save_post', 'jamstack_deployments_fire_webhook_save_post', 10, 3);
+}
+
+if (!function_exists('jamstack_deployments_fire_webhook_transition_post_status')) {
+    /**
+     * Fire a request to the webhook when a the status is changed
+     *
+     * @param string $new
+     * @param string $old
+     * @param WP_Post $post
+     * @return void
+     */
+    function jamstack_deployments_fire_webhook_transition_post_status($new, $old, $post) {
+        \Crgeary\JAMstackDeployments\WebhookTrigger::triggerPostTransition($new, $old, $post);
+    }
+    add_action('transition_post_status', 'jamstack_deployments_fire_webhook_transition_post_status', 10, 3);
 }
 
 if (!function_exists('jamstack_deployments_fire_webhook_created_term')) {


### PR DESCRIPTION
Fixes #32 

It seems `transition_post_status` and `save_post` are both run when you save a post, so only one is needed. The former covers more basis so is the one that remains.

The `save_post` logic is still there for now, but the hook has been disabled.