### PR TITLE
Add support for ACF options pages.

### DIFF
--- a/src/Settings.php
+++ b/src/Settings.php
@@ -74,6 +74,16 @@ class Settings
             'description' => __( 'Only selected taxonomies will trigger a deployment when their terms are created, updated or deleted.', 'wp-jamstack-deployments' ),
             'legend' => 'Taxonomies'
         ]);
+
+        add_settings_field('webhook_acf', __( 'ACF', 'wp-jamstack-deployments' ), ['Crgeary\JAMstackDeployments\Field', 'checkboxes'], $key, 'general', [
+            'name' => "{$key}[webhook_acf]",
+            'value' => isset($option['webhook_acf']) ? $option['webhook_acf'] : [],
+            'choices' => [
+                'options' => __('Options Page', 'wp-jamstack-deployments'),
+            ],
+            'description' => __( 'Only selected ACF locations will trigger a deployment when they\'re saved.', 'wp-jamstack-deployments' ),
+            'legend' => 'ACF'
+        ]);
     }
 
     /**

--- a/src/functions.php
+++ b/src/functions.php
@@ -135,3 +135,19 @@ if (!function_exists('jamstack_deployments_fire_webhook_edit_term')) {
     }
     add_action('edit_term', 'jamstack_deployments_fire_webhook_edit_term', 10, 3);
 }
+
+if (!function_exists('jamstack_deployments_fire_webhook_acf_save_post')) {
+    /**
+     * Fire a request to the webhook when an ACF option page is saved
+     *
+     * @param int $id
+     * @return void
+     */
+    function jamstack_deployments_fire_webhook_acf_save_post($id) {
+        $option = jamstack_deployments_get_options();
+        if (isset($option['webhook_acf']) && in_array('options', $option['webhook_acf'], true) && 'options' === $id) {
+            \Crgeary\JAMstackDeployments\WebhookTrigger::fireWebhook();    
+        }
+    }
+    add_action('acf/save_post', 'jamstack_deployments_fire_webhook_acf_save_post', 10, 3);
+}


### PR DESCRIPTION
Fixes #38 

You'll be able to optionally trigger deployments when ACF options pages are saved.