### PR TITLE
Send a payload with POST requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ From this screen you can configure the following:
 - **Webhook Method** - This is the required method for the webhook request. The available options are `GET` or `POST`. By default the plugin will automatically select `POST`.
 - **Badge Image URL** - An optional field to specify the `src` of a badge, for services that support badges.
 - **Badge Link** - An optional field to specify the `href` of a badge, for services that support badges.
-- **Post Types** - A list of selectable post types that will trigger a Netlify deployment when created, updated or deleted. Note that only selected post types will trigger a deployment.
-- **Taxonomies** - A list of selectable taxonomies that will trigger a Netlify deployment when created, updated or deleted. Note that only selected taxonomies will trigger a deployment.
+- **Post Types** - A list of selectable post types that will trigger a deployment when created, updated or deleted. Note that only selected post types will trigger a deployment.
+- **Taxonomies** - A list of selectable taxonomies that will trigger a deployment when created, updated or deleted. Note that only selected taxonomies will trigger a deployment.
 
 **If you need more control, there are actions & filters you can use to get the job done.**
 
@@ -89,6 +89,12 @@ You can run code directly before or after you fire the webhook using the followi
 
 * Before: `jamstack_deployments_before_fire_webhook`
 * After: `jamstack_deployments_after_fire_webhook`
+
+## Changing Webhook Payload
+
+Since v1.2 the plugin will send a JSON payload with the request which contains information about the action that was taken to trigger the request. You can modify the payload with the `jamstack_deployments_webhook_body_payload` filter.
+
+**Payloads are only sent for POST requests.**
 
 ## Changing Webhook Request Arguments
 

--- a/src/functions.php
+++ b/src/functions.php
@@ -40,10 +40,11 @@ if (!function_exists('jamstack_deployments_fire_webhook')) {
     /**
      * Fire a request to the webhook.
      *
+     * @param null|array $body
      * @return void
      */
-    function jamstack_deployments_fire_webhook() {
-        \Crgeary\JAMstackDeployments\WebhookTrigger::fireWebhook();
+    function jamstack_deployments_fire_webhook($body = null) {
+        \Crgeary\JAMstackDeployments\WebhookTrigger::fireWebhook($body);
     }
 }
 
@@ -51,27 +52,12 @@ if (!function_exists('jamstack_deployments_force_fire_webhook')) {
     /**
      * Fire a request to the webhook immediately. 
      *
+     * @param null|array $body
      * @return void
      */
-    function jamstack_deployments_force_fire_webhook() {
-        \Crgeary\JAMstackDeployments\WebhookTrigger::fireWebhook();
+    function jamstack_deployments_force_fire_webhook($body = null) {
+        \Crgeary\JAMstackDeployments\WebhookTrigger::fireWebhook($body);
     }
-}
-
-if (!function_exists('jamstack_deployments_fire_webhook_save_post')) {
-    /**
-     * Fire a request to the webhook when a post has been saved.
-     *
-     * @param int $id
-     * @param WP_Post $post
-     * @param boolean $update
-     * @return void
-     */
-    function jamstack_deployments_fire_webhook_save_post($id, $post, $update) {
-        \Crgeary\JAMstackDeployments\WebhookTrigger::triggerSavePost($id, $post, $update);
-    }
-    // duplicates functionality of 'transition_post_status'
-    // add_action('save_post', 'jamstack_deployments_fire_webhook_save_post', 10, 3);
 }
 
 if (!function_exists('jamstack_deployments_fire_webhook_transition_post_status')) {
@@ -146,7 +132,12 @@ if (!function_exists('jamstack_deployments_fire_webhook_acf_save_post')) {
     function jamstack_deployments_fire_webhook_acf_save_post($id) {
         $option = jamstack_deployments_get_options();
         if (isset($option['webhook_acf']) && in_array('options', $option['webhook_acf'], true) && 'options' === $id) {
-            \Crgeary\JAMstackDeployments\WebhookTrigger::fireWebhook();    
+            \Crgeary\JAMstackDeployments\WebhookTrigger::fireWebhook([
+                'action' => 'acf_save',
+                'data' => [
+                    'id' => $id,
+                ]
+            ]);    
         }
     }
     add_action('acf/save_post', 'jamstack_deployments_fire_webhook_acf_save_post', 10, 3);


### PR DESCRIPTION
Allow POST requests to include a JSON payload. These requests contain a small amount of information about the action that was taken on the WordPress site.

For example, a post/page update might include:

```
{
  "action": "post_status_transition",
  "data": {
    "id": 1,
    "status": "publish"
  }
}
```

Solves #40 